### PR TITLE
Some changes to make example work on first build

### DIFF
--- a/dist/cornerstoneWebImageLoader.js
+++ b/dist/cornerstoneWebImageLoader.js
@@ -133,7 +133,7 @@ cornerstoneWebImageLoader = {};
           urlCreator.revokeObjectURL(imageUrl);
           deferred.reject();
         };
-      }
+      };
       xhr.send();
       return deferred;
     }

--- a/examples/index.html
+++ b/examples/index.html
@@ -2,13 +2,13 @@
 <html>
 <head>
     <!-- twitter bootstrap CSS stylesheet - included to make things pretty, not needed or used by cornerstone -->
-    <SCRIPT src="bower/js/jquery.min.js"></SCRIPT>
-    <SCRIPT src="bower/js/cornerstone.min.js"></SCRIPT>
-    <SCRIPT src="bower/js/cornerstoneMath.min.js"></SCRIPT>
-    <SCRIPT src="bower/js/cornerstoneTools.min.js"></SCRIPT>
+    <script src="bower/js/jquery.min.js"></script>
+    <script src="bower/js/cornerstone.min.js"></script>
+    <script src="bower/js/cornerstoneMath.min.js"></script>
+    <script src="bower/js/cornerstoneTools.min.js"></script>
     <link href="bower/css/bootstrap.min.css" rel="stylesheet">
     <link href="bower/css/cornerstone.min.css" rel="stylesheet">
-    <script src="cornerstoneWebImageLoader.js"></script>
+    <script src="../dist/cornerstoneWebImageLoader.js"></script>
 </head>
 <body>
 <div class="container">

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -89,7 +89,7 @@ module.exports = function(grunt) {
 
     require('load-grunt-tasks')(grunt);
 
-    grunt.registerTask('buildAll',  ['concat', 'uglify', 'copy']);
+    grunt.registerTask('buildAll',  ['jshint', 'concat', 'uglify', 'copy']);
     grunt.registerTask('default', ['clean', 'buildAll']);
 };
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -7,10 +7,7 @@ module.exports = function(grunt) {
             default: {
                 src: [
                     'dist',
-                    'build',
-                    '../cornerstoneWebImageLoaderBuild/*',
-                    '!../cornerstoneWebImageLoaderBuild/.git'
-
+                    'build'
                 ]
             }
         },
@@ -20,7 +17,7 @@ module.exports = function(grunt) {
                     'bower_components/bootstrap/dist/css/bootstrap.min.css',
                     'bower_components/cornerstone/dist/cornerstone.min.css',
                 ],
-                dest: '../cornerstoneWebImageLoaderBuild/bower/css',
+                dest: 'examples/bower/css',
                 expand: true,
                 flatten: true
             },
@@ -33,7 +30,7 @@ module.exports = function(grunt) {
                     'bower_components/cornerstoneTools/dist/cornerstoneTools.min.js',
                     'bower_components/cornerstoneMath/dist/cornerstoneMath.min.js',
                 ],
-                dest: '../cornerstoneWebImageLoaderBuild/bower/js',
+                dest: 'examples/bower/js',
                 expand: true,
                 flatten: true
             },
@@ -41,23 +38,7 @@ module.exports = function(grunt) {
                 src: [
                     'bower_components/bootstrap/dist/fonts/*',
                 ],
-                dest: '../cornerstoneWebImageLoaderBuild/bower/fonts',
-                expand: true,
-                flatten: true
-            },
-            dist: {
-                src: [
-                    'dist/*'
-                ],
-                dest: '../cornerstoneWebImageLoaderBuild/',
-                expand: true,
-                flatten: true
-            },
-            html: {
-                src: [
-                    'examples/*',
-                ],
-                dest: '../cornerstoneWebImageLoaderBuild/',
+                dest: 'examples/bower/fonts',
                 expand: true,
                 flatten: true
             }

--- a/src/cornerstoneWebImageLoader.js
+++ b/src/cornerstoneWebImageLoader.js
@@ -131,7 +131,7 @@
           urlCreator.revokeObjectURL(imageUrl);
           deferred.reject();
         };
-      }
+      };
       xhr.send();
       return deferred;
     }


### PR DESCRIPTION
Hey,

Is there a reason for the references to a folder called cornerstoneWebImageLoaderBuild?

This PR just changes the gruntfile and example a bit so that we can run the example after a fresh clone + build.