### PR TITLE
ammending version issue w/ bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cornerstoneWebImageLoader",
-    "version": "0.5.3",
+    "version": "0.7.3",
     "description": "Cornerstone ImageLoader for Web Images (PNG, JPG)",
     "keywords": ["medical", "imaging", "JPEG", "PNG", "cornerstone"],
     "author": "Chris Hafey",


### PR DESCRIPTION
This pull request solves this issue https://github.com/chafey/cornerstoneWebImageLoader/issues/9

Please remember to do a publish to npm and bower, so the people using 'bower install' get the latest version.

Thank you!